### PR TITLE
Remove content type from fetch URL POST

### DIFF
--- a/AUSimulator/Scripts/cmi5Controller.js
+++ b/AUSimulator/Scripts/cmi5Controller.js
@@ -19,8 +19,7 @@
                 async: true,
                 url: fetchUrl,
                 type: "POST",
-                dataType: "json",
-                contentType: "application/json; charset=utf-8"
+                dataType: "json"
             })
             .done(function (data) {
                 // Check for error


### PR DESCRIPTION
Setting the `contentType` property in the AJAX call causes the browser to send a CORS pre-flight request (OPTIONS) which isn't necessary for this type of request without a customized header. The header isn't needed in this case because there isn't any JSON content being posted. Removing the line prevents the pre-flight request and therefore means the LMS isn't required to specify the extra CORS headers.
